### PR TITLE
will-change for massively better scrolling perf

### DIFF
--- a/src/styles/config/mixins.sass
+++ b/src/styles/config/mixins.sass
@@ -8,7 +8,7 @@
 	overflow-x: hidden
 	padding: $gutter $gutter 0
 	overflow-scrolling: touch
-  will-change: transform
+	will-change: transform
 
 %scroll-item
 	width: 100%

--- a/src/styles/config/mixins.sass
+++ b/src/styles/config/mixins.sass
@@ -8,6 +8,7 @@
 	overflow-x: hidden
 	padding: $gutter $gutter 0
 	overflow-scrolling: touch
+  will-change: transform
 
 %scroll-item
 	width: 100%


### PR DESCRIPTION
before:
![image](https://cloud.githubusercontent.com/assets/39191/23787619/ba870698-0527-11e7-9aea-dc78c3e9641d.png)


after:
![image](https://cloud.githubusercontent.com/assets/39191/23787640/dbd43c76-0527-11e7-86e6-cbdada2ab2d6.png)

i'm selecting about 40ms in both screenshots.